### PR TITLE
feat: Implement Phase 3 content sections

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,9 @@
 import Hero from '@/components/Hero/Hero';
 import About from '@/components/About/About';
 import Skills from '@/components/Skills/Skills';
+import Experience from '@/components/Experience/Experience';
+import Contact from '@/components/Contact/Contact';
+import Hobbies from '@/components/Hobbies/Hobbies';
 
 export default function Home() {
   return (
@@ -8,6 +11,9 @@ export default function Home() {
       <Hero />
       <About />
       <Skills />
+      <Experience />
+      <Contact />
+      <Hobbies />
     </main>
   );
 }

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useInView } from 'react-intersection-observer';
+import { personalInfo } from '@/lib/data/personal-info';
+import SocialLinks from './SocialLinks';
+
+export default function Contact() {
+  const [ref, inView] = useInView({
+    triggerOnce: true,
+    threshold: 0.1,
+  });
+
+  return (
+    <section id="contact" className="py-20 px-4 relative z-10">
+      <div className="container mx-auto max-w-4xl">
+        <motion.div
+          ref={ref}
+          initial={{ opacity: 0, y: 50 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+          className="terminal-window"
+        >
+          <div className="terminal-header">
+            <div className="terminal-button red"></div>
+            <div className="terminal-button yellow"></div>
+            <div className="terminal-button green"></div>
+          </div>
+
+          <div className="py-6">
+            {/* Section Header */}
+            <motion.div
+              initial={{ opacity: 0, x: -20 }}
+              animate={inView ? { opacity: 1, x: 0 } : {}}
+              transition={{ delay: 0.2, duration: 0.5 }}
+              className="mb-6"
+            >
+              <h2 className="font-pixel text-2xl md:text-3xl text-matrix-green mb-2">
+                {'>> CONNECT.sh'}
+              </h2>
+              <div className="h-1 w-24 bg-matrix-green"></div>
+            </motion.div>
+
+            {/* System Initialization */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={inView ? { opacity: 1 } : {}}
+              transition={{ delay: 0.4, duration: 0.5 }}
+              className="font-terminal text-matrix-green-dark text-sm mb-6 space-y-1"
+            >
+              <p>{'>'} INITIALIZING CONNECTION PROTOCOLS...</p>
+              <p>{'>'} LOADING CONTACT METHODS...</p>
+              <p>{'>'} STATUS: READY TO CONNECT</p>
+            </motion.div>
+
+            {/* Content Grid */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-start">
+              {/* Profile Photo */}
+              <motion.div
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={inView ? { opacity: 1, scale: 1 } : {}}
+                transition={{ delay: 0.6, duration: 0.6 }}
+                className="md:col-span-1"
+              >
+                <div className="relative group">
+                  <div className="absolute inset-0 bg-matrix-green opacity-20 blur-xl group-hover:opacity-30 transition-opacity"></div>
+                  <div className="relative border-4 border-matrix-green p-1 bg-matrix-dark">
+                    {/* Placeholder for profile photo */}
+                    <div className="aspect-square bg-matrix-green-dark flex items-center justify-center">
+                      <span className="text-6xl">👤</span>
+                    </div>
+                  </div>
+                  <div className="mt-3 text-center">
+                    <p className="font-terminal text-matrix-green text-lg">
+                      {personalInfo.name}
+                    </p>
+                    <p className="font-code text-matrix-cyan text-sm">
+                      {personalInfo.role}
+                    </p>
+                  </div>
+                </div>
+              </motion.div>
+
+              {/* Social Links */}
+              <div className="md:col-span-2">
+                <SocialLinks inView={inView} />
+              </div>
+            </div>
+
+            {/* Command Prompt */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={inView ? { opacity: 1 } : {}}
+              transition={{ delay: 1.2, duration: 0.5 }}
+              className="mt-8 font-terminal text-matrix-green text-sm"
+            >
+              <span>{'>'} connection.established</span>
+              <span className="animate-blink ml-1">_</span>
+            </motion.div>
+          </div>
+        </motion.div>
+
+        {/* Pixel Divider */}
+        <div className="pixel-divider"></div>
+      </div>
+    </section>
+  );
+}

--- a/components/Contact/SocialLinks.tsx
+++ b/components/Contact/SocialLinks.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+interface SocialLink {
+  command: string;
+  label: string;
+  url: string;
+  icon: string;
+}
+
+interface SocialLinksProps {
+  inView: boolean;
+}
+
+export default function SocialLinks({ inView }: SocialLinksProps) {
+  const socialLinks: SocialLink[] = [
+    {
+      command: 'send',
+      label: 'EMAIL',
+      url: 'mailto:your.email@example.com',
+      icon: '📧',
+    },
+    {
+      command: 'connect',
+      label: 'LINKEDIN',
+      url: 'https://linkedin.com/in/yourusername',
+      icon: '💼',
+    },
+    {
+      command: 'view',
+      label: 'GITHUB',
+      url: 'https://github.com/yourusername',
+      icon: '🐙',
+    },
+    {
+      command: 'download',
+      label: 'CV (PDF)',
+      url: '/cv.pdf',
+      icon: '📄',
+    },
+    {
+      command: 'view',
+      label: 'CV (MD)',
+      url: '/cv.md',
+      icon: '📝',
+    },
+  ];
+
+  return (
+    <div className="space-y-3">
+      {socialLinks.map((link, index) => (
+        <motion.a
+          key={link.label}
+          href={link.url}
+          target={link.url.startsWith('http') ? '_blank' : undefined}
+          rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
+          initial={{ opacity: 0, x: -20 }}
+          animate={inView ? { opacity: 1, x: 0 } : {}}
+          transition={{ delay: 0.6 + index * 0.1, duration: 0.5 }}
+          className="block group"
+        >
+          <div className="font-terminal text-sm bg-matrix-dark border-2 border-matrix-green px-4 py-3 rounded hover:bg-matrix-green-dark hover:border-matrix-cyan transition-all duration-300 transform hover:translate-x-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-3">
+                <span className="text-2xl">{link.icon}</span>
+                <div>
+                  <span className="text-matrix-cyan">$ {link.command} </span>
+                  <span className="text-matrix-green">{link.label.toLowerCase()}</span>
+                </div>
+              </div>
+              <span className="text-matrix-cyan opacity-0 group-hover:opacity-100 transition-opacity">
+                →
+              </span>
+            </div>
+          </div>
+        </motion.a>
+      ))}
+    </div>
+  );
+}

--- a/components/Experience/Experience.tsx
+++ b/components/Experience/Experience.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useInView } from 'react-intersection-observer';
+import { experiences } from '@/lib/data/experience';
+import ExperienceCard from './ExperienceCard';
+
+export default function Experience() {
+  const [ref, inView] = useInView({
+    triggerOnce: true,
+    threshold: 0.1,
+  });
+
+  return (
+    <section id="experience" className="py-20 px-4 relative z-10">
+      <div className="container mx-auto max-w-4xl">
+        {/* Section Header */}
+        <motion.div
+          ref={ref}
+          initial={{ opacity: 0, y: 50 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+          className="mb-12"
+        >
+          <h2 className="font-pixel text-2xl md:text-3xl text-matrix-green mb-2">
+            {'>> QUEST_LOG.md'}
+          </h2>
+          <div className="h-1 w-24 bg-matrix-green"></div>
+
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={inView ? { opacity: 1 } : {}}
+            transition={{ delay: 0.3, duration: 0.5 }}
+            className="font-terminal text-matrix-cyan text-sm mt-4"
+          >
+            {'>'} Loading quest history...
+          </motion.p>
+        </motion.div>
+
+        {/* Timeline Container */}
+        <div className="relative">
+          {/* Timeline Line */}
+          <motion.div
+            initial={{ height: 0 }}
+            animate={inView ? { height: '100%' } : {}}
+            transition={{ delay: 0.5, duration: 1 }}
+            className="absolute left-4 top-0 w-0.5 bg-matrix-green-dark"
+          ></motion.div>
+
+          {/* Experience Cards */}
+          <div className="space-y-0">
+            {experiences.map((experience, index) => (
+              <ExperienceCard
+                key={experience.id}
+                experience={experience}
+                index={index}
+                inView={inView}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Command Prompt */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={inView ? { opacity: 1 } : {}}
+          transition={{ delay: 1.5, duration: 0.5 }}
+          className="mt-8 font-terminal text-matrix-green text-sm"
+        >
+          <span>{'>'} quest_log.complete</span>
+          <span className="animate-blink ml-1">_</span>
+        </motion.div>
+
+        {/* Pixel Divider */}
+        <div className="pixel-divider"></div>
+      </div>
+    </section>
+  );
+}

--- a/components/Experience/ExperienceCard.tsx
+++ b/components/Experience/ExperienceCard.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+import { Experience } from '@/lib/data/experience';
+
+interface ExperienceCardProps {
+  experience: Experience;
+  index: number;
+  inView: boolean;
+}
+
+export default function ExperienceCard({ experience, index, inView }: ExperienceCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -50 }}
+      animate={inView ? { opacity: 1, x: 0 } : {}}
+      transition={{ delay: 0.2 * index, duration: 0.6 }}
+      className="relative"
+    >
+      {/* Timeline Dot */}
+      <div className="absolute left-0 top-0 w-8 h-8 bg-matrix-dark border-4 border-matrix-green rounded-full flex items-center justify-center">
+        <div className="w-3 h-3 bg-matrix-green rounded-full animate-pulse"></div>
+      </div>
+
+      {/* Level Badge */}
+      <motion.div
+        initial={{ scale: 0 }}
+        animate={inView ? { scale: 1 } : {}}
+        transition={{ delay: 0.3 + 0.2 * index, type: 'spring' }}
+        className="absolute -left-2 -top-2 bg-pixel-red text-ghost font-pixel text-xs px-2 py-1 rounded z-10"
+      >
+        LVL {experience.level}
+      </motion.div>
+
+      {/* Card Content */}
+      <div className="ml-12 terminal-window mb-8">
+        <div className="terminal-header">
+          <div className="terminal-button red"></div>
+          <div className="terminal-button yellow"></div>
+          <div className="terminal-button green"></div>
+        </div>
+
+        <div className="py-4">
+          {/* Quest Header */}
+          <div className="mb-4">
+            <div className="font-pixel text-xs text-matrix-cyan mb-2">
+              LEVEL {experience.level} QUEST COMPLETED
+            </div>
+            <div className="h-px bg-matrix-green mb-3"></div>
+
+            <h3 className="font-terminal text-xl text-matrix-green">
+              {experience.company}
+            </h3>
+            <p className="font-code text-ghost text-sm mt-1">
+              {experience.role}
+            </p>
+            <p className="font-terminal text-matrix-cyan text-xs mt-2">
+              {experience.startDate} → {experience.endDate}
+            </p>
+          </div>
+
+          {/* Expand/Collapse Button */}
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="retro-button text-xs mb-4 w-full"
+          >
+            <span className="font-terminal">
+              {isExpanded ? '▼ HIDE DETAILS' : '▶ SHOW ACHIEVEMENTS'}
+            </span>
+          </button>
+
+          {/* Achievements (Collapsible) */}
+          <motion.div
+            initial={false}
+            animate={{
+              height: isExpanded ? 'auto' : 0,
+              opacity: isExpanded ? 1 : 0,
+            }}
+            transition={{ duration: 0.3 }}
+            className="overflow-hidden"
+          >
+            <div className="space-y-3">
+              <div>
+                <p className="font-terminal text-matrix-cyan text-xs mb-2">
+                  ACHIEVEMENTS:
+                </p>
+                <ul className="space-y-2">
+                  {experience.achievements.map((achievement, idx) => (
+                    <motion.li
+                      key={idx}
+                      initial={{ opacity: 0, x: -20 }}
+                      animate={isExpanded ? { opacity: 1, x: 0 } : {}}
+                      transition={{ delay: idx * 0.1 }}
+                      className="font-code text-ghost text-sm flex items-start"
+                    >
+                      <span className="text-matrix-green mr-2">→</span>
+                      <span>{achievement}</span>
+                    </motion.li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Tech Stack */}
+              <div className="pt-3 border-t border-matrix-green-dark">
+                <p className="font-terminal text-matrix-cyan text-xs mb-2">
+                  XP GAINED:
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {experience.technologies.map((tech, idx) => (
+                    <motion.span
+                      key={tech}
+                      initial={{ scale: 0 }}
+                      animate={isExpanded ? { scale: 1 } : {}}
+                      transition={{ delay: 0.3 + idx * 0.05, type: 'spring' }}
+                      className="font-code text-xs px-3 py-1 bg-matrix-dark border-2 border-matrix-green text-matrix-green rounded hover:bg-matrix-green hover:text-matrix-dark transition-colors duration-200"
+                    >
+                      {tech}
+                    </motion.span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/components/Hobbies/Hobbies.tsx
+++ b/components/Hobbies/Hobbies.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useInView } from 'react-intersection-observer';
+import { hobbies } from '@/lib/data/hobbies';
+
+export default function Hobbies() {
+  const [ref, inView] = useInView({
+    triggerOnce: true,
+    threshold: 0.1,
+  });
+
+  return (
+    <section id="hobbies" className="py-20 px-4 relative z-10">
+      <div className="container mx-auto max-w-4xl">
+        <motion.div
+          ref={ref}
+          initial={{ opacity: 0, y: 50 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+          className="terminal-window"
+        >
+          <div className="terminal-header">
+            <div className="terminal-button red"></div>
+            <div className="terminal-button yellow"></div>
+            <div className="terminal-button green"></div>
+          </div>
+
+          <div className="py-6">
+            {/* Section Header */}
+            <motion.div
+              initial={{ opacity: 0, x: -20 }}
+              animate={inView ? { opacity: 1, x: 0 } : {}}
+              transition={{ delay: 0.2, duration: 0.5 }}
+              className="mb-6"
+            >
+              <h2 className="font-pixel text-2xl md:text-3xl text-matrix-green mb-2">
+                {'>> EXTRA_LIVES.log'}
+              </h2>
+              <div className="h-1 w-24 bg-matrix-green"></div>
+            </motion.div>
+
+            {/* System Initialization */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={inView ? { opacity: 1 } : {}}
+              transition={{ delay: 0.4, duration: 0.5 }}
+              className="font-terminal text-matrix-green-dark text-sm mb-8 space-y-1"
+            >
+              <p>{'>'} LOADING PERSONAL INTERESTS...</p>
+              <p>{'>'} PARSING HOBBY DATABASE...</p>
+              <p>{'>'} STATUS: LOADED</p>
+            </motion.div>
+
+            {/* Hobbies Grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {hobbies.map((hobby, index) => (
+                <motion.div
+                  key={hobby.id}
+                  initial={{ opacity: 0, scale: 0.8, rotateY: -90 }}
+                  animate={inView ? { opacity: 1, scale: 1, rotateY: 0 } : {}}
+                  transition={{
+                    delay: 0.6 + index * 0.1,
+                    duration: 0.6,
+                    type: 'spring',
+                  }}
+                  className="group"
+                >
+                  <div className="bg-matrix-dark border-2 border-matrix-green p-6 rounded hover:border-matrix-cyan hover:bg-matrix-green-dark transition-all duration-300 transform hover:scale-105 hover:shadow-lg hover:shadow-matrix-green/20">
+                    <div className="flex items-start space-x-4">
+                      {/* Icon */}
+                      <motion.div
+                        whileHover={{ rotate: 360, scale: 1.2 }}
+                        transition={{ duration: 0.6 }}
+                        className="text-5xl flex-shrink-0"
+                      >
+                        {hobby.icon}
+                      </motion.div>
+
+                      {/* Content */}
+                      <div className="flex-1">
+                        <h3 className="font-terminal text-lg text-matrix-green group-hover:text-matrix-cyan transition-colors mb-2">
+                          {hobby.name}
+                        </h3>
+                        <p className="font-code text-ghost text-sm">
+                          {hobby.description}
+                        </p>
+                      </div>
+                    </div>
+
+                    {/* Achievement Badge Effect */}
+                    <motion.div
+                      initial={{ width: 0 }}
+                      whileHover={{ width: '100%' }}
+                      transition={{ duration: 0.3 }}
+                      className="h-0.5 bg-gradient-to-r from-matrix-green to-matrix-cyan mt-4"
+                    ></motion.div>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+
+            {/* Command Prompt */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={inView ? { opacity: 1 } : {}}
+              transition={{ delay: 1.2, duration: 0.5 }}
+              className="mt-8 font-terminal text-matrix-green text-sm"
+            >
+              <span>{'>'} extra_lives.loaded</span>
+              <span className="animate-blink ml-1">_</span>
+            </motion.div>
+          </div>
+        </motion.div>
+
+        {/* Pixel Divider */}
+        <div className="pixel-divider"></div>
+      </div>
+    </section>
+  );
+}

--- a/lib/data/experience.ts
+++ b/lib/data/experience.ts
@@ -1,0 +1,58 @@
+export interface Experience {
+  id: string;
+  company: string;
+  role: string;
+  startDate: string;
+  endDate: string;
+  achievements: string[];
+  technologies: string[];
+  level: number;
+}
+
+export const experiences: Experience[] = [
+  {
+    id: "exp-1",
+    company: "Tech Company Inc.",
+    role: "Senior Full Stack Developer",
+    startDate: "Jan 2022",
+    endDate: "Present",
+    achievements: [
+      "Led development of microservices architecture serving 1M+ users",
+      "Reduced API response time by 40% through optimization",
+      "Mentored team of 5 junior developers",
+      "Implemented CI/CD pipeline reducing deployment time by 60%"
+    ],
+    technologies: ["React", "Node.js", "TypeScript", "AWS", "Docker"],
+    level: 3
+  },
+  {
+    id: "exp-2",
+    company: "Digital Solutions Ltd.",
+    role: "Full Stack Developer",
+    startDate: "Mar 2020",
+    endDate: "Dec 2021",
+    achievements: [
+      "Built real-time collaboration features for SaaS platform",
+      "Integrated payment systems processing $2M+ annually",
+      "Improved application performance and user experience",
+      "Collaborated with cross-functional teams on product features"
+    ],
+    technologies: ["Vue.js", "Python", "PostgreSQL", "Redis", "Kubernetes"],
+    level: 2
+  },
+  {
+    id: "exp-3",
+    company: "StartUp Ventures",
+    role: "Frontend Developer",
+    startDate: "Jun 2018",
+    endDate: "Feb 2020",
+    achievements: [
+      "Developed responsive web applications from scratch",
+      "Implemented state management and routing solutions",
+      "Worked closely with designers to create pixel-perfect UIs",
+      "Participated in agile development process"
+    ],
+    technologies: ["React", "JavaScript", "CSS3", "REST APIs"],
+    level: 1
+  }
+];

--- a/lib/data/hobbies.ts
+++ b/lib/data/hobbies.ts
@@ -1,0 +1,33 @@
+export interface Hobby {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+}
+
+export const hobbies: Hobby[] = [
+  {
+    id: "hobby-1",
+    name: "Retro Gaming",
+    description: "Classic arcade games and 8-bit nostalgia",
+    icon: "🎮"
+  },
+  {
+    id: "hobby-2",
+    name: "Open Source",
+    description: "Contributing to community projects",
+    icon: "💻"
+  },
+  {
+    id: "hobby-3",
+    name: "Sci-Fi Reading",
+    description: "Exploring futuristic worlds and concepts",
+    icon: "📚"
+  },
+  {
+    id: "hobby-4",
+    name: "Tech Tinkering",
+    description: "Experimenting with new technologies",
+    icon: "🔧"
+  }
+];


### PR DESCRIPTION
Implements Phase 3 of the landing page plan: Content Sections

Adds three new major sections:
- Experience section with quest log theme, timeline, and collapsible cards
- Contact section with terminal-style social links and commands
- Hobbies section with 8-bit icons and grid layout

All sections follow the Matrix × 8-bit retro gaming aesthetic.

Closes #8

Generated with [Claude Code](https://claude.ai/code)