### PR TITLE
fix: Enable GoatCounter via build-time secret injection

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -52,7 +52,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: BUILDKIT_INLINE_CACHE=1
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            NEXT_PUBLIC_GOATCOUNTER_CODE=${{ secrets.GOATCOUNTER_CODE }}
 
       - name: Verify image
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,16 @@ RUN npm ci
 FROM node:18-alpine AS builder
 WORKDIR /app
 
+# Accept build arguments for Next.js public environment variables
+ARG NEXT_PUBLIC_GOATCOUNTER_CODE
+ENV NEXT_PUBLIC_GOATCOUNTER_CODE=${NEXT_PUBLIC_GOATCOUNTER_CODE}
+
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 # Build the application
+# NEXT_PUBLIC_* environment variables will be embedded in the bundle
 RUN npm run build
 
 # Stage 3: Runner

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -130,6 +130,23 @@ jobs:
 - ✅ Uses GitHub Actions cache for faster builds
 - ✅ Tags image as `latest`
 - ✅ Includes metadata (title, description, revision)
+- ✅ Passes build-time secrets (e.g., `GOATCOUNTER_CODE`) as build arguments
+
+**Build Arguments:**
+
+The workflow passes repository secrets as Docker build arguments:
+
+```yaml
+build-args: |
+  BUILDKIT_INLINE_CACHE=1
+  NEXT_PUBLIC_GOATCOUNTER_CODE=${{ secrets.GOATCOUNTER_CODE }}
+```
+
+These get embedded into the Docker image during build. To add secrets:
+1. Go to **Settings** → **Secrets and variables** → **Actions**
+2. Add repository secret (e.g., `GOATCOUNTER_CODE`)
+3. Secret will be available in next build
+4. See [docs/COUNTER_SOLUTIONS.md](COUNTER_SOLUTIONS.md) for details
 
 ### Best Practices
 


### PR DESCRIPTION
## Summary

Fixes #22 - Visitor counter not displaying on https://dremdem.ru/

## Problem

The GoatCounter visitor counter was implemented correctly but **not showing on production** because:

❌ `NEXT_PUBLIC_GOATCOUNTER_CODE` environment variable was `undefined`  
❌ Next.js `NEXT_PUBLIC_*` vars require **build-time** configuration  
❌ Runtime env vars (via `docker run -e`) don't work for `NEXT_PUBLIC_*`  
❌ Dockerfile didn't accept build arguments  
❌ Documentation incorrectly suggested runtime would work  

## Root Cause

**Next.js Limitation:**
```
NEXT_PUBLIC_* environment variables are embedded into the 
JavaScript bundle during build (npm run build).

They CANNOT be changed at runtime without rebuild.
```

## Solution

Implement **build-time secret injection** via GitHub Actions:

```mermaid
graph LR
    A[GitHub Secret<br/>GOATCOUNTER_CODE] -->|read| B[GitHub Actions<br/>Workflow]
    B -->|--build-arg| C[Docker Build<br/>ARG + ENV]
    C -->|embed| D[Next.js Bundle<br/>JavaScript]
    D -->|deploy| E[Production Site<br/>Counter Visible]
    
    style A fill:#2ea44f,stroke:#1b6635,color:#fff
    style E fill:#0969da,stroke:#0550ae,color:#fff
```

## Changes

### 1. **Dockerfile** ✅

Added build argument support:

```dockerfile
# Stage 2: Builder
ARG NEXT_PUBLIC_GOATCOUNTER_CODE
ENV NEXT_PUBLIC_GOATCOUNTER_CODE=${NEXT_PUBLIC_GOATCOUNTER_CODE}

RUN npm run build  # ← Env var now available here!
```

### 2. **GitHub Actions Workflow** ✅

Updated `.github/workflows/docker-release.yml`:

```yaml
build-args: |
  BUILDKIT_INLINE_CACHE=1
  NEXT_PUBLIC_GOATCOUNTER_CODE=${{ secrets.GOATCOUNTER_CODE }}
```

### 3. **Documentation** ✅

**docs/COUNTER_SOLUTIONS.md:**
- ❌ Removed incorrect "Runtime (recommended)" option
- ✅ Added "Step 2: Configure GitHub Secret" with instructions
- ✅ Added "Step 3: Trigger Build from Master"
- ✅ Added "Step 4: Deploy to Production"
- ✅ Clarified build-time requirement throughout
- ✅ Updated troubleshooting section

**docs/DEPLOYMENT.md:**
- ✅ Added "Build Arguments" section to CI/CD Workflow
- ✅ Documented secrets usage
- ✅ Cross-referenced COUNTER_SOLUTIONS.md

## How It Works Now

```
1. Repository Secret: GOATCOUNTER_CODE = "dremdem" ✅ (already added)
   ↓
2. Trigger Docker Release workflow from master
   ↓
3. GitHub Actions reads secrets.GOATCOUNTER_CODE
   ↓
4. Passes as --build-arg during docker build
   ↓
5. Dockerfile accepts ARG and sets as ENV
   ↓
6. Next.js embeds value into JavaScript bundle
   ↓
7. Image pushed to ghcr.io/dremdem/cv_profile:latest
   ↓
8. Pull new image on droplet
   ↓
9. Counter appears on https://dremdem.ru/ 🎉
```

## Testing

- ✅ Local Docker build with `--build-arg NEXT_PUBLIC_GOATCOUNTER_CODE=test` succeeds
- ✅ Build completes successfully
- ✅ Documentation updated and validated
- ✅ Workflow configuration syntax verified

## Deployment Steps (After Merge)

1. **Merge this PR to master**
2. **Trigger workflow:**
   - Go to Actions tab
   - Select "Docker Release" workflow
   - Click "Run workflow" (ensure master selected)
   - Wait for build to complete (~2-5 minutes)
3. **Deploy on droplet:**
   ```bash
   ssh root@your-droplet-ip
   docker pull ghcr.io/dremdem/cv_profile:latest
   docker stop cv-profile && docker rm cv-profile
   docker run -d --name cv-profile --restart unless-stopped \
     -p 127.0.0.1:3000:3000 ghcr.io/dremdem/cv_profile:latest
   ```
4. **Verify:** Visit https://dremdem.ru/ → scroll to Contact section → see counter!

## Files Changed

- `Dockerfile` - Add ARG/ENV for build-time injection
- `.github/workflows/docker-release.yml` - Pass secret as build-arg
- `docs/COUNTER_SOLUTIONS.md` - Complete rewrite of setup instructions
- `docs/DEPLOYMENT.md` - Add build arguments documentation

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)