### PR TITLE
feat: Redesign visitor counter with custom Matrix-themed display

### DIFF
--- a/components/Contact/VisitorCounter.tsx
+++ b/components/Contact/VisitorCounter.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import { useState, useEffect } from 'react';
 
 interface VisitorCounterProps {
   goatCounterCode?: string;
@@ -8,14 +9,45 @@ interface VisitorCounterProps {
 }
 
 export default function VisitorCounter({ goatCounterCode, inView }: VisitorCounterProps) {
+  const [count, setCount] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
   // Only render if GoatCounter is configured
   if (!goatCounterCode) {
     return null;
   }
 
-  // GoatCounter SVG counter URL
-  // Format: https://[code].goatcounter.com/counter/.svg for site-wide total
-  const counterUrl = `https://${goatCounterCode}.goatcounter.com/counter/.svg`;
+  useEffect(() => {
+    // Only fetch when component is in view
+    if (!inView) return;
+
+    const fetchCount = async () => {
+      try {
+        // GoatCounter JSON API endpoint for site-wide total
+        const response = await fetch(
+          `https://${goatCounterCode}.goatcounter.com/counter/.json`,
+          { cache: 'no-store' }
+        );
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch counter');
+        }
+
+        const data = await response.json();
+        // Extract count from response (formatted string like "1,234")
+        setCount(data.count || '0');
+        setError(false);
+      } catch (err) {
+        console.error('Error fetching visitor count:', err);
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCount();
+  }, [goatCounterCode, inView]);
 
   return (
     <motion.div
@@ -25,22 +57,35 @@ export default function VisitorCounter({ goatCounterCode, inView }: VisitorCount
       className="mt-6 font-terminal text-matrix-green-dark text-sm flex items-center gap-3"
     >
       <span className="text-matrix-green">{'>'} VISITORS_LOGGED:</span>
+
       <div className="relative inline-block">
         {/* Glowing background effect */}
-        <div className="absolute inset-0 bg-matrix-cyan opacity-10 blur-sm"></div>
+        <div className="absolute inset-0 bg-matrix-green opacity-20 blur-md animate-pulse"></div>
 
         {/* Counter badge with Matrix styling */}
-        <div className="relative border border-matrix-green/30 bg-matrix-dark/80 px-3 py-1">
-          <img
-            src={counterUrl}
-            alt="Visitor count"
-            className="inline-block opacity-90 brightness-125 contrast-125 hue-rotate-[60deg] saturate-150"
-            style={{
-              filter: 'brightness(1.25) contrast(1.25) hue-rotate(60deg) saturate(1.5)',
-              imageRendering: 'pixelated',
-            }}
-          />
+        <div className="relative border-2 border-matrix-green bg-matrix-dark/90 px-4 py-2 shadow-lg shadow-matrix-green/20">
+          {loading ? (
+            <span className="text-matrix-green-dark text-xs">LOADING...</span>
+          ) : error ? (
+            <span className="text-red-500 text-xs">ERROR</span>
+          ) : (
+            <motion.span
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ duration: 0.3 }}
+              className="text-matrix-green font-bold text-lg tracking-wider drop-shadow-[0_0_8px_rgba(0,255,65,0.8)]"
+              style={{ textShadow: '0 0 10px rgba(0, 255, 65, 0.8)' }}
+            >
+              {count}
+            </motion.span>
+          )}
         </div>
+
+        {/* Corner accents for cool effect */}
+        <div className="absolute -top-1 -left-1 w-2 h-2 border-t-2 border-l-2 border-matrix-cyan"></div>
+        <div className="absolute -top-1 -right-1 w-2 h-2 border-t-2 border-r-2 border-matrix-cyan"></div>
+        <div className="absolute -bottom-1 -left-1 w-2 h-2 border-b-2 border-l-2 border-matrix-cyan"></div>
+        <div className="absolute -bottom-1 -right-1 w-2 h-2 border-b-2 border-r-2 border-matrix-cyan"></div>
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
Addresses #26 - Redesign visitor counter to be bright, cool-looking, and match the project's Matrix aesthetic

This PR replaces the GoatCounter SVG image approach with a custom-designed counter that fetches data from the GoatCounter JSON API, allowing for complete visual customization.

## Changes

### Visual Design
- ✅ **Bright Matrix green numbers** with large, bold font
- ✅ **Multiple glow layers** using text-shadow and drop-shadow for brightness
- ✅ **Pulsing background glow** for dynamic effect
- ✅ **Cyan corner bracket accents** for hacker/terminal aesthetic
- ✅ **Smooth animations** - number scales in when loaded
- ✅ **Enhanced border and shadows** for depth

### Technical Improvements
- ✅ **JSON API instead of SVG** - More resource-efficient
- ✅ **Client-side data fetching** using React hooks
- ✅ **Performance optimization** - Only fetches when component is in view
- ✅ **Proper error handling** with loading and error states
- ✅ **Custom styling control** - Full control over appearance

### Code Quality
- ✅ TypeScript compilation passes
- ✅ Production build successful
- ✅ No ESLint/type errors

## Before vs After

**Before:**
- GoatCounter SVG image with CSS filters
- Limited styling customization
- Fixed appearance determined by GoatCounter

**After:**
- Custom Matrix-themed design
- Bright, glowing green numbers
- Cyan corner accents
- Animated entrance effect
- Loading and error states
- Matches project aesthetic perfectly

## API Reference
Using GoatCounter's official JSON endpoint as documented:
- Endpoint: `https://[code].goatcounter.com/counter/.json`
- Returns: `{"count": "formatted_number", "count_unique": "formatted_number"}`
- Documentation: https://www.goatcounter.com/help/visitor-counter

## Test Plan
- [x] TypeScript compilation successful
- [x] Production build passes
- [x] Component renders without errors
- [ ] Verify on production deployment (after merge)
- [ ] Check CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)