### PR TITLE
fix: Change deployment log to user-writable location

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,8 +7,9 @@ set -e  # Exit on error
 
 # Configuration
 DEPLOY_USER="github-deploy"
-COMPOSE_FILE="/home/${DEPLOY_USER}/cv_profile/docker-compose.yml"
-LOG_FILE="/var/log/cv-profile-deploy.log"
+PROJECT_DIR="/home/${DEPLOY_USER}/cv_profile"
+COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yml"
+LOG_FILE="${PROJECT_DIR}/deploy.log"
 MAX_HEALTH_CHECK_WAIT=60  # seconds
 HEALTH_CHECK_INTERVAL=5   # seconds
 


### PR DESCRIPTION
## Problem

Deployment fails with permission error:
```
tee: /var/log/cv-profile-deploy.log: Permission denied
Error: Process completed with exit code 1
```

**Root cause:** The `github-deploy` non-root user cannot write to `/var/log/` directory.

**GitHub Actions run:** https://github.com/dremdem/cv_profile/actions/runs/20291718019/job/58277449898

## Solution

Change log file location from `/var/log/cv-profile-deploy.log` to `~/cv_profile/deploy.log`

**Benefits:**
- ✅ User-writable location (no permission issues)
- ✅ Maintains non-root security
- ✅ Logs co-located with deployment files
- ✅ Easy to access for debugging

## Changes

**File:** `deploy.sh`

```diff
# Configuration
DEPLOY_USER="github-deploy"
-COMPOSE_FILE="/home/${DEPLOY_USER}/cv_profile/docker-compose.yml"
-LOG_FILE="/var/log/cv-profile-deploy.log"
+PROJECT_DIR="/home/${DEPLOY_USER}/cv_profile"
+COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yml"
+LOG_FILE="${PROJECT_DIR}/deploy.log"
```

**New log location:** `/home/github-deploy/cv_profile/deploy.log`

## Testing

After this fix, deployment should complete successfully. Logs will be accessible via:

```bash
ssh github-deploy@DROPLET_IP "cat ~/cv_profile/deploy.log"
```

## Security Note

This fix maintains the non-root security posture. The `github-deploy` user:
- ✅ Can write to own home directory
- ❌ Cannot write to /var/log/ (as intended)
- ❌ Still has no root/sudo access

Fixes deployment failure from PR #29