### PR TITLE
docs: Update deployment log location in documentation

### DIFF
--- a/docs/AUTOMATED_DEPLOYMENT.md
+++ b/docs/AUTOMATED_DEPLOYMENT.md
@@ -348,7 +348,7 @@ Watch the workflow execution:
 SSH to your droplet and check deployment logs:
 
 ```bash
-ssh github-deploy@YOUR_DROPLET_IP "tail -50 /var/log/cv-profile-deploy.log"
+ssh github-deploy@YOUR_DROPLET_IP "tail -50 ~/cv_profile/deploy.log"
 ```
 
 **Expected output:**
@@ -521,15 +521,15 @@ EOF
 
 ### Issue: Deployment logs not found
 
-**Error:** `/var/log/cv-profile-deploy.log: No such file or directory`
+**Error:** `~/cv_profile/deploy.log: No such file or directory`
 
 **Solution:**
-Create log file (requires root):
-```bash
-ssh root@YOUR_DROPLET_IP "touch /var/log/cv-profile-deploy.log && chmod 666 /var/log/cv-profile-deploy.log"
-```
+The log file is created automatically by the deployment script in the user's home directory. If it's missing, it will be created on the next deployment run.
 
-**Note:** Log file needs world-writable permissions (666) so `github-deploy` user can write to it.
+To check if it exists:
+```bash
+ssh github-deploy@YOUR_DROPLET_IP "ls -la ~/cv_profile/deploy.log"
+```
 
 ---
 
@@ -584,7 +584,7 @@ EOF
 
 ```bash
 # View recent deployments
-ssh github-deploy@YOUR_DROPLET_IP "tail -100 /var/log/cv-profile-deploy.log"
+ssh github-deploy@YOUR_DROPLET_IP "tail -100 ~/cv_profile/deploy.log"
 
 # Check container status
 ssh github-deploy@YOUR_DROPLET_IP "docker ps -f name=cv-profile"
@@ -692,6 +692,6 @@ If you encounter issues not covered in this guide:
 
 **Log Locations:**
 - GitHub Actions: Repository → Actions → Workflow run
-- Deployment: `/var/log/cv-profile-deploy.log` on droplet
+- Deployment: `~/cv_profile/deploy.log` on droplet
 - Application: `docker logs cv-profile` on droplet
 - Nginx: `/var/log/nginx/error.log` on droplet


### PR DESCRIPTION
## Summary

Update documentation to reflect the new deployment log location after PR #30.

## Changes

**Old location:** `/var/log/cv-profile-deploy.log` (requires root permissions)  
**New location:** `~/cv_profile/deploy.log` (user-writable)

### Files Updated

**docs/AUTOMATED_DEPLOYMENT.md:**
- ✅ Step 6.3: Check Deployment Logs
- ✅ Troubleshooting: Deployment logs not found
- ✅ Monitoring: Check Deployment Status  
- ✅ Support: Log Locations reference

### Improvements

1. **Removed outdated workaround**
   - Deleted instructions to create log file with root
   - Log file now created automatically by script

2. **Updated all commands**
   ```bash
   # Before
   ssh github-deploy@DROPLET "tail -50 /var/log/cv-profile-deploy.log"
   
   # After  
   ssh github-deploy@DROPLET "tail -50 ~/cv_profile/deploy.log"
   ```

3. **Simplified troubleshooting**
   - No need for special permissions setup
   - Log file auto-created on first deployment

## Context

This documentation update follows the fixes in PR #30 which changed the log location to resolve permission issues with the non-root `github-deploy` user.

**Related PRs:**
- #29 - Automated deployment (merged)
- #30 - Fix log permissions and container conflict (merged)

## Verification

All references to `/var/log/cv-profile-deploy.log` have been updated to `~/cv_profile/deploy.log`:

```bash
grep -r "/var/log/cv-profile-deploy.log" docs/
# No results ✅
```