### PR TITLE
fix: Stop old container before deploying new one

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -64,6 +64,12 @@ if ! docker-compose pull; then
 fi
 log "Image pulled successfully"
 
+# Stop old container if it exists (to avoid name conflict)
+if [ -n "$CURRENT_CONTAINER" ]; then
+    log "Stopping current container: $CURRENT_CONTAINER"
+    docker stop "$CURRENT_CONTAINER" || log_warning "Failed to stop container"
+fi
+
 # Deploy new container
 log "Deploying new container..."
 if ! docker-compose up -d; then


### PR DESCRIPTION
## Problem

Deployment fails with container name conflict:
```
ERROR: Cannot create container for service cv-profile: Conflict.
The container name "/cv-profile" is already in use by container "316371961e7e..."
```

**Root cause:** Existing container from previous deployment prevents docker-compose from creating new container with same name.

**Failed run:** https://github.com/dremdem/cv_profile/actions/runs/20291959617/job/58278129557

---

## Solution

Stop the old container **before** deploying the new one.

### Code Change

**File:** `deploy.sh` (line 67, after image pull)

```bash
# Stop old container if it exists (to avoid name conflict)
if [ -n "$CURRENT_CONTAINER" ]; then
    log "Stopping current container: $CURRENT_CONTAINER"
    docker stop "$CURRENT_CONTAINER" || log_warning "Failed to stop container"
fi
```

---

## Deployment Flow (After Fix)

```
1. Save current container ID ← for rollback
2. Pull new image from GHCR
3. Stop old container       ← NEW: Prevents name conflict
4. Start new container (docker-compose up -d)
5. Health check (60s)
6. Success → Remove old container
7. Failure → Rollback (restart old container)
```

---

## Why This Works

- **Before deployment:** Old container is stopped (but not removed)
- **During deployment:** docker-compose can create new container (no name conflict)
- **If success:** Old container removed in cleanup
- **If failure:** Old container restarted for rollback

---

## Note

This commit was originally part of PR #30 but wasn't included in the merge. Creating separate PR to ensure this critical fix gets into master.

**Original commit:** `1668ad7`

Fixes container conflict error from deployment run.