### PR TITLE
fix: Update CV PDF link to latest version

### DIFF
--- a/components/Contact/SocialLinks.tsx
+++ b/components/Contact/SocialLinks.tsx
@@ -42,8 +42,8 @@ export default function SocialLinks({ inView }: SocialLinksProps) {
     },
     {
       command: 'cv-pdf',
-      label: 'yakovenko_python_en.pdf',
-      url: 'https://github.com/dremdem/cv/blob/master/yakovenko_python_en.pdf',
+      label: 'yakovenko_python_en_latest.pdf',
+      url: 'https://github.com/dremdem/cv/blob/master/yakovenko_python_en_latest.pdf',
       icon: '📄',
     },
     {


### PR DESCRIPTION
## Summary

Updates the CV PDF link in the Contact section to point to the correct file.

## Change

| Field | Before | After |
|-------|--------|-------|
| Label | `yakovenko_python_en.pdf` | `yakovenko_python_en_latest.pdf` |
| URL | `.../yakovenko_python_en.pdf` | `.../yakovenko_python_en_latest.pdf` |

**File:** `components/Contact/SocialLinks.tsx:45-46`

## Test plan

- [ ] Verify link opens correct PDF: https://github.com/dremdem/cv/blob/master/yakovenko_python_en_latest.pdf

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)